### PR TITLE
Fix filename(case-sensitive) of QNHttpDelegate.h importing.

### DIFF
--- a/QiniuSDK/Storage/QNFormUpload.h
+++ b/QiniuSDK/Storage/QNFormUpload.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "QNUploadManager.h"
-#import "QNhttpDelegate.h"
+#import "QNHttpDelegate.h"
 #import "QNUpToken.h"
 
 @class QNHttpManager;

--- a/QiniuSDK/Storage/QNResumeUpload.h
+++ b/QiniuSDK/Storage/QNResumeUpload.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "QNUploadManager.h"
-#import "QNhttpDelegate.h"
+#import "QNHttpDelegate.h"
 #import "QNUpToken.h"
 #import "QNFileDelegate.h"
 


### PR DESCRIPTION
This could cause failure when depending on this SDK by CocoaPods.