### PR TITLE
Fixed a fileSize overflow issue.

### DIFF
--- a/QiniuSDK/Common/QNFile.m
+++ b/QiniuSDK/Common/QNFile.m
@@ -37,8 +37,7 @@
 			}
 			return self;
 		}
-		NSNumber *fileSizeNumber = fileAttr[NSFileSize];
-		_fileSize = [fileSizeNumber intValue];
+		_fileSize = [fileAttr fileSize];
 		NSDate *modifyTime = fileAttr[NSFileModificationDate];
 		int64_t t = 0;
 		if (modifyTime != nil) {


### PR DESCRIPTION
Use file attribute's fileSize method which returns an unsigned long long value instead of intValue to prevent overflow when file size is bigger than 2GB.